### PR TITLE
Revert "CL-12170 Achieve ticket title goal for Spirit-ESIS process."

### DIFF
--- a/lib/baldr/grammar/version4010/set856.rb
+++ b/lib/baldr/grammar/version4010/set856.rb
@@ -25,7 +25,7 @@ module Baldr::Grammar::Version4010::Set856
         {id: 'PID', min: 0, max: 200},
         {id: 'MEA', min: 0, max: 297},
         {id: 'PWK', min: 0, max: 25},
-        {id: 'PKG', min: 0, max: 99999},
+        {id: 'PKG', min: 0, max: 25},
         {id: 'TD1', min: 0, max: 20},
         {id: 'TD5', min: 0, max: 12},
         {id: 'TD3', min: 0, max: 12},


### PR DESCRIPTION
Reverts cloudlogistics/baldr#11

Wrong version. Last bump was from 8 to 9. Didn't update branch before PR.

https://github.com/cloudlogistics/baldr/commit/0f9a2abc111aaafd9ec6d3d5ed9b7f35eaed6f5b#diff-e79a60dc6b85309ae70a6ea8261eaf95
https://github.com/cloudlogistics/cloudlogistics/pull/4956/files