### PR TITLE
BUGS-6304 Update transaction counts after validation trim

### DIFF
--- a/lib/baldr/parser.rb
+++ b/lib/baldr/parser.rb
@@ -54,7 +54,7 @@ class Baldr::Parser
 
   def validate
     if @roots
-      @roots.each { |e| Baldr::Validator.validate!(e, @grammar) }
+      @roots.each { |e| Baldr::Validator.validate!(e, @grammar, {truncate_loops: false}) }
       @roots.each { |e| Baldr::Types.convert_after_parse!(e, @grammar) }
     end
   rescue Baldr::Error => e

--- a/lib/baldr/validator.rb
+++ b/lib/baldr/validator.rb
@@ -44,6 +44,11 @@ module Baldr::Validator
       raise Baldr::Error::ValidationError, "spare segments #{loop.id}"
     end
 
+    #If we have truncated loops, the segments may need to udpate any values that
+    #are based on the quantity
+    if options[:truncate_loops]
+      segment.prepare!
+    end
     method = "validate_#{segment.id.downcase}!"
     if grammar.respond_to?(method)
       grammar.send(method, segment)

--- a/lib/baldr/validator.rb
+++ b/lib/baldr/validator.rb
@@ -3,7 +3,7 @@ module Baldr::Validator
   extend self
 
   def validate!(envelope, grammar, options={})
-    options[:truncate_loops] = options.fetch(:truncate_loops, false)
+    options[:truncate_loops] = options.fetch(:truncate_loops, true)
     validate_tree!(envelope, grammar, grammar.structure, options)
   end
 

--- a/lib/baldr/version.rb
+++ b/lib/baldr/version.rb
@@ -1,3 +1,3 @@
 module Baldr
-  VERSION = '0.10.5'
+  VERSION = '0.10.6'
 end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -122,6 +122,134 @@ class GoodBuilderFromRealLife
     end
   end
 
+  def build_long(builder)
+    builder.ST do |st|
+      st.ST01 '204'
+      st.ST02 '000000006'
+
+      st.B2 do |n|
+        n.B202 'ODFL'
+        n.B204 '04000000000000060'
+        n.B206 'PP'
+      end
+
+      st.B2A do |n|
+        n.B2A01 '00'
+        n.B2A02 'ZZ'
+      end
+
+      st.G62 do |n|
+        n.G6201 '64'
+        n.G6202 '20121109'
+      end
+
+      #This is 10 over the original number
+      20.times do
+        st.NTE do |nte|
+          nte.NTE01 'OTH'
+          nte.NTE02 "super special carrier instructions"
+        end
+      end
+
+      segment_n1(st)
+
+      st.S5 do
+        S501 1
+        S502 'CL'
+
+        G62 do
+          G6201 '10'
+          G6202 '20121130'
+          G6203 'I'
+          G6204 '1400'
+          G6205 'LT'
+        end
+
+        G62 do
+          G6201 '10'
+          G6202 '20121130'
+          G6203 'K'
+          G6204 '1630'
+          G6205 'LT'
+        end
+
+        AT8 do
+          AT801 'E'
+          AT802 'L'
+          AT803 145.0
+          AT804 8
+          AT806 'E'
+          AT807 0
+        end
+
+        N1 do
+          N101 'SH'
+          N102 'AEROFLEX USA'
+
+          N3 do
+            N301 '1102 N Main st'
+          end
+
+          N4 do
+            N401 'SWEETWATER'
+            N402 'TN'
+            N403 '37874'
+            N404 'US'
+          end
+        end
+      end
+
+      st.S5 do
+        S501 2
+        S502 'CU'
+
+        AT8 do
+          AT801 'E'
+          AT802 'L'
+          AT803 145.0
+          AT804 8
+          AT806 'E'
+          AT807 0
+        end
+
+        N1 do
+          N101 'CN'
+          N102 'Koch Air- INDY'
+
+          N3 do
+            N301 '5620 DIVIDEND DRIVE'
+          end
+
+          N4 do
+            N401 'INDIANAPOLIS'
+            N402 'IN'
+            N403 '46241'
+            N404 'US'
+          end
+        end
+
+        OID do
+          OID02 'K0822'
+          OID04 'PC'
+          OID05 1
+          OID06 'L'
+          OID07 145.0
+          OID08 'E'
+          OID09 0
+        end
+      end
+
+      st.L3 do
+        L301 145
+        L302 'G'
+        L309 0
+        L310 'E'
+        L311 8
+        L312 'L'
+      end
+    end
+  end
+
   def segment_n1(parent)
     parent.N1 do
       N101 'BT'
@@ -331,6 +459,95 @@ describe Baldr::Builder do
     }
     output = Baldr::Renderer::X12.draw(b.envelope, {separators: separators})
     output.should eq input
+  end
+
+  it 'should throw error if too long and truncate is disabled' do
+    b = Baldr::Builder.new(
+      #standard_version_number: '',
+      sender_id: '4233372493',
+      sender_id_qualifier: 'ZZ',
+      receiver_id_qualifier: '02',
+      receiver_id: 'ODFL',
+      date_time: DateTime.parse('121109 1642'),
+      interchange_control_number: '000000002',
+      usage_indicator: 'P',
+      acknowledgment_requested: '1',
+      functional_groups_control_numbers: {
+        'SM' => '2'
+      }
+    )
+
+    #This method will specifically add more data than is allowed by the grammar
+    GoodBuilderFromRealLife.new.build_long(b)
+    b.build_functional_groups
+    b.prepare!
+
+    Baldr::Types.convert_before_render!(b.envelope, Baldr::Grammar::Envelope)
+    expect {
+      Baldr::Validator.validate!(b.envelope, Baldr::Grammar::Envelope, { truncate_loops: false })
+    }.to raise_error(/loop is too long/)
+  end
+
+  it 'should truncate loops by default' do
+    b = Baldr::Builder.new(
+      #standard_version_number: '',
+      sender_id: '4233372493',
+      sender_id_qualifier: 'ZZ',
+      receiver_id_qualifier: '02',
+      receiver_id: 'ODFL',
+      date_time: DateTime.parse('121109 1642'),
+      interchange_control_number: '000000002',
+      usage_indicator: 'P',
+      acknowledgment_requested: '1',
+      functional_groups_control_numbers: {
+        'SM' => '2'
+      }
+    )
+
+    #This method will specifically add more data than is allowed by the grammar
+    GoodBuilderFromRealLife.new.build_long(b)
+    b.build_functional_groups
+    b.prepare!
+
+    se01_orig_sum = b.envelope.transactions[0]['SE01']
+
+    Baldr::Types.convert_before_render!(b.envelope, Baldr::Grammar::Envelope)
+    Baldr::Validator.validate!(b.envelope, Baldr::Grammar::Envelope)
+
+    se01_new_sum = b.envelope.transactions[0]['SE01']
+
+    expect(se01_new_sum).to be < se01_orig_sum
+  end
+
+  it 'should update transaction sum' do
+    b = Baldr::Builder.new(
+      #standard_version_number: '',
+      sender_id: '4233372493',
+      sender_id_qualifier: 'ZZ',
+      receiver_id_qualifier: '02',
+      receiver_id: 'ODFL',
+      date_time: DateTime.parse('121109 1642'),
+      interchange_control_number: '000000002',
+      usage_indicator: 'P',
+      acknowledgment_requested: '1',
+      functional_groups_control_numbers: {
+        'SM' => '2'
+      }
+    )
+
+    #This method will specifically add more data than is allowed by the grammar
+    GoodBuilderFromRealLife.new.build_long(b)
+    b.build_functional_groups
+    b.prepare!
+
+    se01_orig_sum = b.envelope.transactions[0]['SE01']
+
+    Baldr::Types.convert_before_render!(b.envelope, Baldr::Grammar::Envelope)
+    Baldr::Validator.validate!(b.envelope, Baldr::Grammar::Envelope, { truncate_loops: true })
+
+    se01_new_sum = b.envelope.transactions[0]['SE01']
+
+    expect(se01_new_sum).to be < se01_orig_sum
   end
 
   it 'should fail' do


### PR DESCRIPTION
When the validations run with the 'truncate' option on, the transaction
ST values are not updated with the correct number of segments. By
calling `prepare!` when the truncation option has been turned on, it
updates the particular segment (transaction, envelope, or otherwise)
with the new number.

Dev note: it appears that some of the test case data that is listed as
being valid is not valid, e.g. some ST01 values are either nonexistent
when they are required for the particular format, or they have
inaccurate values.