### PR TITLE
BUGS-6634 Filter out X12 control characters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    baldr (0.10.5)
+    baldr (0.10.7)
       activesupport
 
 GEM

--- a/lib/baldr/renderer/x12.rb
+++ b/lib/baldr/renderer/x12.rb
@@ -2,6 +2,9 @@ module Baldr::Renderer::X12
 
   extend self
 
+  #TODO: There is an implicit out-of-band knowledge of which character is used
+  #      for the component separator in envelope.rb ; this needs to be removed
+  #      and the addition/construction of that character should be done here.
   DEFAULT_SEPARATORS = {
     element: '*',
     segment: '~',
@@ -17,6 +20,21 @@ module Baldr::Renderer::X12
 
   def draw_segment(segment, separators)
     a = [segment.id] + segment.elements.reverse.drop_while{ |i| i.nil? }.reverse
+    #TODO: due to construction methods, if the last element in a segment is nil,
+    #      it won't currently be printed, and if another element requires it,
+    #      no error will be thrown.
+
+    #Due to the TODO item concerning the component separator, it is actively
+    #removed from the below regex
+    substitution_regex =
+      Regexp.new "[#{separators.reject{|k,_| k.to_s == "component" }.values.join}]+"
+
+    #This removes X12 control characters from any segement element that may have
+    #them, removing potential parse conflicts.
+    altered = a.map! { |value|
+      value.nil? ? nil :
+      value.gsub(substitution_regex,"")
+    }
 
     ["#{a.join(separators[:element])}#{separators[:segment]}"] + segment.children.map{ |l| draw_loop(l, separators) }
   end

--- a/lib/baldr/version.rb
+++ b/lib/baldr/version.rb
@@ -1,3 +1,3 @@
 module Baldr
-  VERSION = '0.10.6'
+  VERSION = '0.10.7'
 end


### PR DESCRIPTION
Elements that had X12 control characters weren't filtered out, leading
to potential parsing errors of generated EDI files.