### PR TITLE
Bugs-6634

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    baldr (0.10.7)
+    baldr (0.10.8)
       activesupport
 
 GEM

--- a/lib/baldr/renderer/x12.rb
+++ b/lib/baldr/renderer/x12.rb
@@ -27,7 +27,7 @@ module Baldr::Renderer::X12
     #Due to the TODO item concerning the component separator, it is actively
     #removed from the below regex
     substitution_regex =
-      Regexp.new "[#{separators.reject{|k,_| k.to_s == "component" }.values.join}]+"
+      Regexp.new "#{Regexp.escape(separators[:element])}|#{Regexp.escape(separators[:segment])}"
 
     #This removes X12 control characters from any segement element that may have
     #them, removing potential parse conflicts.

--- a/lib/baldr/version.rb
+++ b/lib/baldr/version.rb
@@ -1,3 +1,3 @@
 module Baldr
-  VERSION = '0.10.7'
+  VERSION = '0.10.8'
 end


### PR DESCRIPTION
Additional parameters would get constructed as part of the regex, even
if they were not valid separators.
