### PR TITLE
Fix for Segment ISA not found when upgrading ruby to v3 on CL

### DIFF
--- a/lib/baldr/builder.rb
+++ b/lib/baldr/builder.rb
@@ -3,7 +3,7 @@ class Baldr::Builder
   attr_accessor :envelope
 
   def initialize(params = {})
-    @envelope = Baldr::Envelope.new(params[:options])
+    @envelope = Baldr::Envelope.new('ISA', **params[:options])
     @transactions = []
 
     Baldr::Envelope.helpers.each do |f|


### PR DESCRIPTION
Broker app of CL breaks when upgrading ruby from v2.7.0 to v3.0.0 with following debug steps:

![image](https://github.com/user-attachments/assets/38b46dac-9c71-4aa0-9f30-ba074e504c9b)
